### PR TITLE
Option for printing CSV headers before continuous printing

### DIFF
--- a/src/Experiment.cpp
+++ b/src/Experiment.cpp
@@ -190,7 +190,7 @@ void Experiment::printResult()
 
 void Experiment::run_single()
 {
-	Sampler sampler(settings::interval, settings::counters, settings::continuous_print_flag);
+	Sampler sampler(settings::interval, settings::counters, settings::continuous_print_flag, settings::continuous_header_flag);
 
 	if (settings::before.count() > 0) {
 		sampler.start();

--- a/src/Sampler.h
+++ b/src/Sampler.h
@@ -14,7 +14,7 @@ struct Sampler
 	using result_t = std::vector<units::energy::joule_t>;
 	std::vector<PowerDataSourcePtr> counters;
 
-	Sampler(std::chrono::milliseconds interval, const std::vector<std::string> & counterOrAliasNames, bool continuous_print_flag = false);
+	Sampler(std::chrono::milliseconds interval, const std::vector<std::string> & counterOrAliasNames, bool continuous_print_flag = false, bool continuous_header_flag = false);
 	virtual ~Sampler();
 
 	void start(std::chrono::milliseconds delay = std::chrono::milliseconds(0));

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -8,6 +8,7 @@
 namespace settings {
 
 bool continuous_print_flag = false;
+bool continuous_header_flag = false;
 bool energy_delayed_product = false;
 bool print_counter_list = false;
 
@@ -47,6 +48,7 @@ void printHelpAndExit(char *progname, int exitcode = 0)
 	std::cout << "\t-h Print this help and exit" << std::endl;
 	std::cout << "\t-l Print a list of available counters and exit" << std::endl;
 	std::cout << "\t-c Continuously print power levels (mW) to stdout (skip energy stats)" << std::endl;
+	std::cout << "\t-n If continuously printing, print the counter names before each run" << std::endl;
 	std::cout << "\t-p Measure energy-delayed product (measure joules if not provided)" << std::endl;
 	std::cout << "\t-e Comma seperated list of measured counters (default: all available)" << std::endl;
 	std::cout << "\t-r Number of runs (default: " << runs << ")" << std::endl;
@@ -63,7 +65,7 @@ void printHelpAndExit(char *progname, int exitcode = 0)
 void readProgArgs(int argc, char *argv[])
 {
 	int c;
-	while ((c = getopt (argc, argv, "hlcpe:r:d:i:b:a:")) != -1) {
+	while ((c = getopt (argc, argv, "hlcnpe:r:d:i:b:a:")) != -1) {
 		switch (c) {
 			case 'h':
 			case '?':
@@ -71,6 +73,9 @@ void readProgArgs(int argc, char *argv[])
 				break;
 			case 'c':
 				continuous_print_flag = true;
+				break;
+			case 'n':
+				continuous_header_flag = true;
 				break;
 			case 'p':
 				energy_delayed_product = true;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -63,8 +63,11 @@ void printHelpAndExit(char *progname, int exitcode = 0)
 
 // --------------------------------------------------------------
 
-enum Longopt {header = 256};
-static const struct option longopts[] = {
+enum Longopt {
+	header = 256
+};
+
+static struct option longopts[] = {
 	{"header", no_argument, NULL, header},
 	{0, 0, 0, 0}
 };
@@ -72,7 +75,7 @@ static const struct option longopts[] = {
 void readProgArgs(int argc, char *argv[])
 {
 	int c;
-	while ((c = getopt_long (argc, argv, "hlcnpe:r:d:i:b:a:", longopts, NULL)) != -1) {
+	while ((c = getopt_long (argc, argv, "hlcpe:r:d:i:b:a:", longopts, NULL)) != -1) {
 		switch (c) {
 			case 'h':
 			case '?':

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -12,6 +12,7 @@ namespace settings {
 
 // Configurable via command line options
 extern bool continuous_print_flag;
+extern bool continuous_header_flag;
 extern bool energy_delayed_product;
 extern bool print_counter_list;
 


### PR DESCRIPTION
Adds a `--header` option for use with continuous printing (`-c`). If specified, the output looks like this:
```
$ pinpoint -c --header -e CPU,RAM -- sleep 1
CPU,RAM
3384,1108
2646,605
2659,575
2762,583
2775,571
2895,652
...
```