### PR TITLE
Throw runtime error if pinpoint couldn't get data from MCP

### DIFF
--- a/src/data_sources/MCP_EasyPower.cpp
+++ b/src/data_sources/MCP_EasyPower.cpp
@@ -37,7 +37,8 @@ struct OpenMCPDevice
 	{
 		// FIXME: Possible data race (though atm not called from different threads)
 		if (has_read[channel]) {
-			f511_get_power(&data[0], &data[1], fd);
+			if (0 != f511_get_power(&data[0], &data[1], fd))
+				throw std::runtime_error("Cannot get power from MCP.");
 			has_read[0] = false;
 			has_read[1] = false;
 		}


### PR DESCRIPTION
Currently, if pinpoint can't get the power from the MCP (for example, if there is a bitflip and the communication checksum doesn't match, or if the MCP didn't send an ACK package), then pinpoint just silently omits that error and reports the old power values.

With this change, pinpoint instead throws a runtime error in such cases.