### PR TITLE
Add flag to skip execution of workload

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -9,6 +9,8 @@
 namespace settings {
 
 bool continuous_print_flag = false;
+bool continuous_timestamp_flag = false; // print the timestamp before each measurement if using -c
+bool no_workload_flag = false; // skip execution of workload and print continuously with -c (needs -c to be set)
 bool continuous_header_flag = false;
 bool countinous_timestamp_flag = false;
 bool energy_delayed_product = false;
@@ -59,6 +61,7 @@ void printHelpAndExit(char *progname, int exitcode = 0)
 	std::cout << "\t-i Sampling interval in ms (default: " << interval.count() << ")" << std::endl;
 	std::cout << "\t-b Start measurement N ms before worker creation (negative values will delay start)" << std::endl;
 	std::cout << "\t-a Continue measurement N ms after worker exited" << std::endl;
+	std::cout << "\t-n Disable execution of workload. Only works with -c" << std::endl;
 	std::cout << "\t-U Run the workload under this uid" << std::endl;
 	std::cout << std::endl;
 	std::cout << "\t--header If continuously printing, print the counter names before each run" << std::endl;
@@ -82,7 +85,7 @@ static struct option longopts[] = {
 void readProgArgs(int argc, char *argv[])
 {
 	int c;
-	while ((c = getopt_long (argc, argv, "hlcpe:r:d:i:b:a:U:", longopts, NULL)) != -1) {
+	while ((c = getopt_long (argc, argv, "hlcpne:r:d:i:b:a:U:", longopts, NULL)) != -1) {
 		switch (c) {
 			case 'h':
 			case '?':
@@ -122,6 +125,9 @@ void readProgArgs(int argc, char *argv[])
 			case 'U':
 				uid = atoi(optarg);
 				break;
+			case 'n':
+			     no_workload_flag = true;
+			     break;
 			case header:
 				continuous_header_flag = true;
 				break;
@@ -133,7 +139,7 @@ void readProgArgs(int argc, char *argv[])
 		}
 	}
 
-	if (!(optind < argc)) {
+	if (!(optind < argc) || no_workload_flag) {
 		workload_and_args = nullptr;
 	} else {
 		workload_and_args = &argv[optind];
@@ -154,7 +160,13 @@ void validate()
 		}
 		exit(0);
 	}
-	if (!workload_and_args) {
+
+	if (no_workload_flag && !continuous_print_flag) {
+		std::cerr << "-n only works if continous output (-c) is enabled." << std::endl;
+		exit(1);
+	}
+	
+	if (!workload_and_args && !(no_workload_flag && continuous_print_flag)) {
 		std::cerr << "Missing workload" << std::endl;
 		exit(1);
 	}

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -14,6 +14,7 @@ namespace settings {
 extern bool continuous_print_flag;
 extern bool continuous_header_flag;
 extern bool	countinous_timestamp_flag;
+extern bool no_workload_flag;
 extern bool energy_delayed_product;
 extern bool print_counter_list;
 


### PR DESCRIPTION
Currently the `-c` option does not (reliably) support execution of pinpoint without a workload. It is still useful to get data from pinpoint without a workload - especially if just getting the raw data of a power-meter is the goal like in a project I am working on. This PR introduces a `-n` flag to skip the need of a workload.

`pinpoint -c -e CPU -` was initially used to execute without a workload. However, I think this is a bug and not really a supported feature. Moreover, this command does not reliably run forever: Sometimes it terminates immediately which I think is due to a race condition related to not having a valid workload.

Alternatively, the `-c` command could be updated to have different semantics if no workload is given.

This change needs an entry in the README file, but #13 should probably be merged first.