### PR TITLE
Make -c and --total flag work together

### DIFF
--- a/src/PinPointLib.cpp
+++ b/src/PinPointLib.cpp
@@ -16,7 +16,7 @@ void setup_for_continous_printing(std::ostream & output_stream, bool print_heade
 	settings::output_stream.rdbuf(output_stream.rdbuf());
 	settings::continuous_print_flag = true;
 	settings::continuous_header_flag = print_headers;
-	settings::countinous_timestamp_flag = print_timestamps;
+	settings::continous_timestamp_flag = print_timestamps;
 }
 
 PowerDataSourcePtr openCounter(const std::string & name)

--- a/src/Sampler.cpp
+++ b/src/Sampler.cpp
@@ -49,7 +49,7 @@ Sampler::Sampler(std::chrono::milliseconds interval, const std::vector<std::stri
 
 	std::function<void()> atick  = [this]{accumulate_tick();};
 	std::function<void()> cptick = [this]{continuous_print_tick();};
-	std::function<void()> bothtick = [this]{accumulate_tick();continuous_print_tick();};
+	std::function<void()> bothtick = [this]{continuous_print_tick();accumulate_tick();};
 
 	if (settings::continuous_print_flag && settings::continuous_header_flag) {
 		if (settings::countinous_timestamp_flag)
@@ -61,7 +61,7 @@ Sampler::Sampler(std::chrono::milliseconds interval, const std::vector<std::stri
 		m_detail->csv_header.back() = '\n';
 	}
 
-	if (settings::continuous_print_flag && settings::countinous_timestamp_flag) {
+	if (settings::continuous_print_flag && settings::continous_timestamp_flag) {
 		settings::output_stream << std::fixed << std::setprecision(4);
 	}
 
@@ -146,7 +146,7 @@ void Sampler::continuous_print_tick()
 		buf[pos - 1] = ',';
 	}
 	buf[pos - 1] = '\0';
-	if (settings::countinous_timestamp_flag) {
+	if (settings::continous_timestamp_flag) {
 		// I wanted to use duration<float, ratio<1>>, but this resulted in weird constant epoch
 		auto ms_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(timestamp.time_since_epoch()).count();
 		settings::output_stream << ms_since_epoch * 0.001 << ",";

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -14,7 +14,7 @@ bool continuous_print_flag = false;
 bool continuous_timestamp_flag = false; // print the timestamp before each measurement if using -c
 bool no_workload_flag = false; // skip execution of workload and print continuously with -c (needs -c to be set)
 bool continuous_header_flag = false;
-bool countinous_timestamp_flag = false;
+bool continous_timestamp_flag = false;
 bool energy_delayed_product = false;
 bool print_counter_list = false;
 
@@ -154,7 +154,7 @@ void readProgArgs(int argc, char *argv[])
 				continuous_header_flag = true;
 				break;
 			case timestamp:
-				countinous_timestamp_flag = true;
+				continous_timestamp_flag = true;
 				break;
 			case total:
 				print_total_flag = true;

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -9,7 +9,7 @@ namespace settings {
 // Configurable via command line options
 extern bool continuous_print_flag;
 extern bool continuous_header_flag;
-extern bool	countinous_timestamp_flag;
+extern bool	continous_timestamp_flag;
 extern bool no_workload_flag;
 
 extern bool energy_delayed_product;


### PR DESCRIPTION
## Bug

When running pinpoint with the `-c` and `--total` flag, the output contained mostly lines filled with zeros and some values.

```bash
$ pinpoint -c --total ./workload
0,0,0,0
0,0,0,0
0,0,0,0
0,0,0,0
...
```

## Solution

By swapping `accumulate_tick();continuous_print_tick();` in `bothtick` (`Sampler.cpp`), every line contains useful output.

```bash
$ pinpoint -c --total ./workload
0,0,0,0
1622,2077,76,4247
2328,2240,67,4933
2368,2261,75,5010
```

## Additionally

A minor typo fix